### PR TITLE
fix typo in Switch Position Mode

### DIFF
--- a/docs/v5/position/position-mode.mdx
+++ b/docs/v5/position/position-mode.mdx
@@ -23,7 +23,7 @@ It supports to switch the position mode for **USDT perpetual** and **Inverse fut
         <td>Initial setting</td><td>one-way</td><td>never configured</td><td>never configured</td>
     </tr>
     <tr>
-        <td>Result</td><td colspan="3">All USDT perpetual trading pairs are one-way molde</td>
+        <td>Result</td><td colspan="3">All USDT perpetual trading pairs are one-way mode</td>
     </tr>
     <tr>
         <td><b>Change 1</b></td><td>-</td><td>-</td><td>Set BTCUSDT to hedge-mode</td>


### PR DESCRIPTION
As the title says.

`molde` -> `mode`