### PR TITLE
Create Subaccount Transfer API tips

### DIFF
--- a/docs/v3/account-asset/transfer/subacct-transfer.mdx
+++ b/docs/v3/account-asset/transfer/subacct-transfer.mdx
@@ -10,8 +10,11 @@ Transfer funds between the parent and child (sub) accounts.
 To send a transfer which is [accountType](enum#accounttype) & parent/sub agnostic, use the [Create Universal Transfer](uni-transfer#) endpoint.
 
 :::tip
+* Please note that the transferId field in the incoming request data of this interface is UUID globally unique
+* This interface can only be used for transfer between parent and child accounts
 * A subaccount can only be attributed to a parent account.
 * If you encounter errorCode: `131228` and msg: `your balance is not enough`, please go to [Get Single Coin Balance](coin-balance#) to check transfer safe amount.
+* It's mandatory to utilize the API key of the main account
 :::
 
 ### HTTP Request

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/v3/account-asset/transfer/subacct-transfer.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/v3/account-asset/transfer/subacct-transfer.mdx
@@ -13,7 +13,8 @@ slug: /account-asset/sub-transfer
 * 請註意該接口入參請求數據中的transferId字段為UUID全局唯一。
 * 該接口只能用於母子賬號之間的劃轉。
 * 一個子賬號只會歸屬於一個母賬號。
-* 如果您遇到錯誤碼是`131228`並且錯誤信息是`your balance is not enough`, 請前往[查詢賬戶單個幣種余額](coin-balance#)接口確認安全限額.
+* 如果您遇到錯誤碼是`131228`並且錯誤信息是`your balance is not enough`, 請前往[查詢賬戶單個幣種余額](coin-balance#)接口確認安全限額。
+* 使用此API端点必须使用主账户的API key
 :::
 
 ### HTTP 請求


### PR DESCRIPTION
For Create Subaccount Transfer API align the english version's tip with Chinese version and also add a new tip must to use api key of main account
