### PR TITLE
Fix navbar stretching

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -212,7 +212,7 @@ const config = {
               {
                 type: 'doc',
                 docId: 'pilot-feature/pilot',
-                label: 'Pilot Feature',
+                label: 'Pilot Features',
               },
               {
                 type: 'doc',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,26 +205,29 @@ const config = {
             label: 'Tax API V3',
           },
           {
-            type: 'doc',
-            docId: 'pilot-feature/pilot',
-            position: 'left',
-            label: 'Pilot Feature',
-          },
-          {
-            type: 'doc',
-            docId: 'changelog/v5',
-            position: 'left',
-            label: 'Changelog',
-          },
-          {
-            to: '/api-explorer/v5/category',
-            position: 'left',
-            label: 'API Explorer',
-          },
-          {
-            to: '/faq',
+            type: 'dropdown',
             position: 'right',
-            label: 'FAQ',
+            label: 'Extras',
+            items: [
+              {
+                type: 'doc',
+                docId: 'pilot-feature/pilot',
+                label: 'Pilot Feature',
+              },
+              {
+                type: 'doc',
+                docId: 'changelog/v5',
+                label: 'Changelog',
+              },
+              {
+                to: '/api-explorer/v5/category',
+                label: 'API Explorer',
+              },
+              {
+                to: '/faq',
+                label: 'FAQ',
+              }
+            ]
           },
           {
             type: 'localeDropdown',


### PR DESCRIPTION
Too many items on the navbar results in the navbar getting crowded and pushing titles onto to multiple lines, distorting the navbar.

The top is the original and the bottom is the new navbar, with the extra items moved into the dropdown menu

<img width="1114" alt="Screenshot 2025-06-11 at 7 30 11 PM" src="https://github.com/user-attachments/assets/8dfaae61-9418-4db4-a103-7a30467ef861" />
