### PR TITLE
Remove delta, gamma, vega, and theta from position docs

### DIFF
--- a/docs/v5/position/position.mdx
+++ b/docs/v5/position/position.mdx
@@ -52,10 +52,6 @@ GET `/v5/position/list`
 |> stopLoss | string  |Stop loss price|
 |> trailingStop | string  |Trailing stop (the distance from market price)|
 |> sessionAvgPrice | string  |USDC contract session avg price, it is the same figure as avg entry price shown in the web UI |
-|> delta | string  |Delta|
-|> gamma | string  |Gamma|
-|> vega | string  |Vega|
-|> theta | string  |Theta|
 |> unrealisedPnl | string  |Unrealised PnL|
 |> curRealisedPnl | string  |The realised PnL for the current holding position|
 |> cumRealisedPnl | string  |Cumulative realised pnl <ul><li>Futures & Perps: it is the all time cumulative realised P&L</li><li>Option: always "", meaningless</li></ul>|


### PR DESCRIPTION
Removed delta, gamma, vega, and theta fields from the documentation.