### PR TITLE
docs(tradfi): refine format, Rollover table, and consolidated instruments table

### DIFF
--- a/docs/v5/tradfi-integration.mdx
+++ b/docs/v5/tradfi-integration.mdx
@@ -3,6 +3,9 @@ title: TradFi Integration
 sidebar_label: TradFi Integration
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 This guide explains how to integrate with Bybit's TradFi (Traditional Finance) products via the existing V5 API, including how to distinguish between MT5-based instruments and Bybit-native equity perpetuals, how to sign required agreements, and how to trade.
 
 ## Distinguish MT5 & Equity Perp Listing
@@ -16,8 +19,8 @@ Access via the Web UI: navigate to **Trade → TradFi**. This section covers for
 
 ### Bybit Platform (Native)
 Access via the main **Trade** menu. This includes all standard Bybit product types:
-- **Spot**: xStock tokens (e.g., TSLA, AAPL, GOOG)
-- **Futures**: Metals perpetuals (XAU, XAG), crude oil perpetuals
+- **Spot**: xStock tokens (e.g., TSLAX, AAPLX, GOOGLX)
+- **Futures**: Stock perpetuals (e.g., TSLAUSDT), metals perpetuals (XAU, XAG), crude oil perpetuals
 - **Options**: Options contracts settled in USDT, including tokenised gold options (XAUTUSDT-Options)
 
 ![Bybit Trading Menu](/img/tradfi-bybit-trading.png)
@@ -31,7 +34,7 @@ Before trading traditional asset perpetuals, please review the applicable terms 
 
 ## Sign Agreement by Main Account
 
-To trade commodity contracts (metals and crude oil), users must first sign the trading agreement. This can be done in two ways:
+To trade commodity contracts (metals and crude oil) or stock perpetuals, users must first sign the trading agreement. Stock perpetuals share the same agreement as metals. This can be done in two ways:
 
 ### Option 1: Via Web UI
 When attempting to trade for the first time, a **Trading Terms** pop-up will appear. Check the checkbox and click **Confirm** to accept.
@@ -45,10 +48,14 @@ Only the **master account** can sign the agreement via Web UI. Please ensure you
 ### Option 2: Via API
 Use the [Sign Agreement](/v5/user/sign-agreement) endpoint to sign programmatically.
 
+:::info
+* Only the **master account** can sign the agreement. Subaccounts are not supported for this action.
+* Once the master account has signed, all subaccounts will be eligible to trade.
+* The API key must have at least one of the following permissions: **Account Transfer**, **Subaccount Transfer**, or **Withdrawal**.
+:::
+
 #### HTTP Request
-```
-POST /v5/user/agreement
-```
+<APIEndpoint method="POST" url="/v5/user/agreement" />
 
 #### Request Parameters
 | Parameter | Required | Type | Comments|
@@ -57,13 +64,13 @@ POST /v5/user/agreement
 |categoryV2 |false |integer |`1`: Metals commodity contracts (XAU & XAG). Stock perps share this agreement<br/>`2`: Crude oil commodity contract<br/>_Either `category` or `categoryV2` is required. Recommend using this field; new enum values will be added here going forward._|
 |agree |**true** |boolean |`true`|
 
-:::info
-* Only the **master account** can sign the agreement. Subaccounts are not supported for this action.
-* Once the master account has signed, all subaccounts will be eligible to trade.
-* The API key must have at least one of the following permissions: **Account Transfer**, **Subaccount Transfer**, or **Withdrawal**.
-:::
+#### Response Parameters
+None
 
 #### Request Example
+
+<Tabs groupId="programming-languages">
+<TabItem value="http" label="HTTP">
 
 ```http
 POST /v5/user/agreement HTTP/1.1
@@ -73,6 +80,7 @@ X-BAPI-API-KEY: XXXXXX
 X-BAPI-TIMESTAMP: 1772695036541
 X-BAPI-RECV-WINDOW: 5000
 Content-Type: application/json
+Content-Length: 40
 
 {
     "agree": true,
@@ -80,64 +88,94 @@ Content-Type: application/json
 }
 ```
 
-## Index Price Roll Mechanism
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+from pybit.unified_trading import HTTP
+session = HTTP(
+    testnet=True,
+    api_key="xxxxxxxxxxxxxxxxxx",
+    api_secret="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+)
+print(session.sign_agreement(
+    category=2,
+    agree=True
+))
+```
+
+</TabItem>
+</Tabs>
+
+#### Response Example
+
+```json
+{
+    "retCode": 0,
+    "retMsg": "success",
+    "result": {},
+    "retExtInfo": {},
+    "time": 1772695037330
+}
+```
+
+## Index Price Rollover Mechanism
 
 The index price of perpetual futures is derived from the respective underlying futures contracts. As commodities do not have a traditional spot market, the external reference price is determined based on designated futures contracts.
 
-The underlying contracts will undergo a rollover (contract transition). During this period, the reference price will gradually shift from the current active contract to the next active contract.
+Before the underlying contract expires, a rollover (contract transition) is performed: the reference price gradually shifts from the front-month contract to the next-month contract over several days, according to a predefined weight schedule.
 
-For example, for `CLUSDT` (Crude Oil), the reference is currently based on the `WTIK6` contract and will transition to `WTIM6` according to the following schedule:
+The weight allocation during the rollover period follows this schedule:
 
-- **April 9, 2026** — 60% near-month contract, 40% next-month contract
-- **April 10, 2026** — 40% near-month contract, 60% next-month contract
-- **April 13, 2026** — 20% near-month contract, 80% next-month contract
-- **April 14, 2026** — 0% near-month contract, 100% next-month contract (rollover completed)
+<div style={{width: 'fit-content', whiteSpace: 'nowrap'}}>
+
+| Day | Front-Month Weight | Next-Month Weight |
+|:---|:---|:---|
+| Day 1 | 80% | 20% |
+| Day 2 | 60% | 40% |
+| Day 3 | 40% | 60% |
+| Day 4 | 20% | 80% |
+| Day 5 | 0% | 100% (Rollover Completed) |
+
+</div>
+
+For example, `CLUSDT` (Crude Oil) uses this mechanism to transition between its designated underlying futures contracts (e.g., from `WTIK6` to `WTIM6`).
 
 :::info
-This mechanism is continuously refined. For the latest rollover schedules and full details, please refer to the Help Center article: [Introduction to TradFi Perpetual Contracts](https://www.bybit.com/en/help-center/article/Introduction-to-TradFi-Perpetual-Contracts?category=4d5d8649cba144c1a8).
+For the latest rollover schedules and full details, please refer to the Help Center article: [Introduction to TradFi Perpetual Contracts](https://www.bybit.com/en/help-center/article/Introduction-to-TradFi-Perpetual-Contracts?category=4d5d8649cba144c1a8).
 :::
 
 To query the current components and their weights contributing to an index price, use the [Get Index Price Components](/v5/market/index-components) endpoint:
 
-```
-GET /v5/market/index-price-components?indexName={symbol}
-```
+<APIEndpoint method="GET" url="/v5/market/index-price-components" />
+
+Query parameter: `indexName={symbol}`
 
 The response includes each component's exchange, spot pair, equivalent price, multiplier, and weight used in the index calculation.
 
-## Instruments Info for xStock & Stock & Commodities
+## Instruments Info for xStock, Stock & Commodities
 
 Use the [Get Instruments Info](/v5/market/instrument) endpoint together with the `symbolType` filter to retrieve trading rules and metadata for TradFi instruments. See the [symbolType enum](/v5/enum#symboltype) for all supported values.
 
-### xStock tokens (Spot)
+<APIEndpoint method="GET" url="/v5/market/instruments-info" />
 
-Query with `category=spot` and `symbolType=xstocks` to list all xStock tokens (e.g., `TSLAXUSDT`, `AAPLXUSDT`, `NVDAXUSDT`).
+<div style={{width: 'fit-content'}}>
 
-```
-GET https://api.bybit.com/v5/market/instruments-info?category=spot&symbolType=xstocks&limit=1000
-```
+| Product | `category` | `symbolType` | Example Symbols | Notable Fields |
+|:---|:---|:---|:---|:---|
+| xStock tokens | `spot` | `xstocks` | `TSLAXUSDT`, `AAPLXUSDT`, `NVDAXUSDT` | `xstockMultiplier` |
+| Stock perpetuals | `linear` | `stock` | `TSLAUSDT` | — |
+| Commodity perpetuals | `linear` | `commodity` | `XAUUSDT`, `XAGUSDT`, `CLUSDT` | — |
 
-The response includes xStock-specific fields such as `xstockMultiplier` and `symbolType: "xstocks"`.
+</div>
 
-### Equity Perpetuals (Linear)
+Stock and commodity perpetuals return standard linear contract fields (leverage, tick size, funding interval, etc.).
 
-Query with `category=linear` and `symbolType=stock` to list all equity perpetuals (e.g., `TSLAUSDT`, `TSMUSDT`, `INTCUSDT`, `HOODUSDT`).
-
-```
-GET https://api.bybit.com/v5/market/instruments-info?category=linear&symbolType=stock&limit=1000
-```
-
-The response includes `symbolType: "stock"` along with standard linear contract fields (leverage, tick size, funding interval, etc.).
-
-### Commodity Perpetuals (Linear)
-
-Query with `category=linear` and `symbolType=commodity` to list all commodity perpetuals (e.g., `XAUUSDT`, `XAGUSDT`, `CLUSDT`).
+Example request:
 
 ```
-GET https://api.bybit.com/v5/market/instruments-info?category=linear&symbolType=commodity&limit=1000
+GET /v5/market/instruments-info?category=linear&symbolType=stock&limit=1000
 ```
-
-The response includes `symbolType: "commodity"` along with standard linear contract fields (leverage, tick size, funding interval, etc.).
 
 ## Trade via Existing API
 
@@ -156,4 +194,9 @@ After signing the agreement, you can trade TradFi-related instruments (metals pe
 - [Get Borrow Quota (Spot)](/v5/order/spot-borrow-quota)
 - [Pre Check Order](/v5/order/pre-check-order)
 
-Simply pass the appropriate `symbol` (e.g., `XAUUSDT`, `XAGUSDT` for metals; oil-related symbols for crude oil contracts) and `category` in your request.
+Simply pass the appropriate `category` and `symbol` in your request:
+
+- **xStock tokens**: `category=spot`, `symbol` e.g., `TSLAXUSDT`, `AAPLXUSDT`
+- **Stock perpetuals**: `category=linear`, `symbol` e.g., `TSLAUSDT`
+- **Metals perpetuals**: `category=linear`, `symbol` e.g., `XAUUSDT`, `XAGUSDT`
+- **Crude oil perpetual**: `category=linear`, `symbol`: `CLUSDT`

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/v5/tradfi-integration.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/v5/tradfi-integration.mdx
@@ -3,6 +3,9 @@ title: TradFi 接入指南
 sidebar_label: TradFi 接入指南
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 本指南說明如何透過現有的 V5 API 接入 Bybit 的 TradFi（傳統金融）產品，包括如何區分 MT5 相關的交易產品與 Bybit 平台原生的合約、如何簽署所需協議，以及如何進行交易。
 
 ## 區分 MT5 與 Equity Perp 上架
@@ -16,8 +19,8 @@ Bybit 提供兩條傳統資產交易路徑：
 
 ### Bybit 平台（原生）
 透過主選單 **Trade** 進入，包含所有標準的 Bybit 產品類型：
-- **現貨（Spot）**：xStock 代幣（如 TSLA、AAPL、GOOG）
-- **合約（Futures）**：貴金屬永續合約（XAU、XAG）、原油永續合約
+- **現貨（Spot）**：xStock 代幣（如 TSLAX、AAPLX、GOOGLX）
+- **合約（Futures）**：股票永續合約（如 TSLAUSDT）、貴金屬永續合約（XAU、XAG）、原油永續合約
 - **期權（Options）**：以 USDT 結算的期權合約，包括代幣化黃金期權（XAUTUSDT-Options）
 
 ![Bybit 交易選單](/img/tradfi-bybit-trading.png)
@@ -31,7 +34,7 @@ Bybit 提供兩條傳統資產交易路徑：
 
 ## 母帳戶簽署協議
 
-交易大宗商品合約（貴金屬與原油）前，用戶必須先簽署交易協議，可透過以下兩種方式完成：
+交易大宗商品合約（貴金屬與原油）或股票永續合約前，用戶必須先簽署交易協議。股票永續合約與貴金屬共用同一份協議。可透過以下兩種方式完成：
 
 ### 方式一：透過 Web UI
 首次嘗試交易時，系統會彈出 **Trading Terms** 視窗，勾選核取方塊並點擊 **Confirm** 即可接受。
@@ -45,10 +48,14 @@ Bybit 提供兩條傳統資產交易路徑：
 ### 方式二：透過 API
 使用 [簽署協議](/v5/user/sign-agreement) 介面以程式化方式簽署。
 
+:::info
+* 請使用**母帳戶**呼叫介面，子帳戶不支援此操作。
+* 母帳戶簽署後，旗下所有子帳戶即可進行交易。
+* API key 權限需具備其中之一：**帳戶劃轉**、**母子帳戶劃轉**、**提幣**。
+:::
+
 #### HTTP 請求
-```
-POST /v5/user/agreement
-```
+<APIEndpoint method="POST" url="/v5/user/agreement" />
 
 #### 請求參數
 | 參數 | 是否必需 | 類型 | 說明|
@@ -57,13 +64,13 @@ POST /v5/user/agreement
 |categoryV2 |false |integer |`1`: 貴金屬（黃金、白銀）合約協議，股票永續合約共用此協議<br/>`2`: 原油合約協議<br/>_`category` 與 `categoryV2` 二選一必傳。建議使用此字段，後續新增的枚舉值將統一添加至此字段。_|
 |agree |**true** |boolean |`true`|
 
-:::info
-* 請使用**母帳戶**呼叫介面，子帳戶不支援此操作。
-* 母帳戶簽署後，旗下所有子帳戶即可進行交易。
-* API key 權限需具備其中之一：**帳戶劃轉**、**母子帳戶劃轉**、**提幣**。
-:::
+#### 響應參數
+無
 
 #### 請求示例
+
+<Tabs groupId="programming-languages">
+<TabItem value="http" label="HTTP">
 
 ```http
 POST /v5/user/agreement HTTP/1.1
@@ -73,6 +80,7 @@ X-BAPI-API-KEY: XXXXXX
 X-BAPI-TIMESTAMP: 1772695036541
 X-BAPI-RECV-WINDOW: 5000
 Content-Type: application/json
+Content-Length: 40
 
 {
     "agree": true,
@@ -80,28 +88,68 @@ Content-Type: application/json
 }
 ```
 
-## 指數價格展期機制（Index Price Roll Mechanism）
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+from pybit.unified_trading import HTTP
+session = HTTP(
+    testnet=True,
+    api_key="xxxxxxxxxxxxxxxxxx",
+    api_secret="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+)
+print(session.sign_agreement(
+    category=2,
+    agree=True
+))
+```
+
+</TabItem>
+</Tabs>
+
+#### 響應示例
+
+```json
+{
+    "retCode": 0,
+    "retMsg": "success",
+    "result": {},
+    "retExtInfo": {},
+    "time": 1772695037330
+}
+```
+
+## 指數價格展期機制（Index Price Rollover Mechanism）
 
 永續期貨的指數價格源自各自的標的期貨合約。由於大宗商品並無傳統的現貨市場，因此外部參考價格將根據指定的期貨合約來確定。
 
-標的合約會進行展期換月（contract rollover），在此期間，參考價格將從當前有效合約逐步過渡至下一個有效合約。
+在標的合約到期前，系統會進行展期換月（contract rollover）：參考價格將依照預定的權重時程，於數日內從前月合約（front-month）逐步過渡至下月合約（next-month）。
 
-以 `CLUSDT`（原油）為例，目前參考的是 `WTIK6` 合約，並將依以下時程展期至 `WTIM6`：
+展期期間的權重分配依照下表進行：
 
-- **2026 年 4 月 9 日** — 60% 近月合約，40% 下月合約
-- **2026 年 4 月 10 日** — 40% 近月合約，60% 下月合約
-- **2026 年 4 月 13 日** — 20% 近月合約，80% 下月合約
-- **2026 年 4 月 14 日** — 0% 近月合約，100% 下月合約（展期完成）
+<div style={{width: 'fit-content', whiteSpace: 'nowrap'}}>
+
+| 日期 | 前月合約權重（Front-Month） | 下月合約權重（Next-Month） |
+|:---|:---|:---|
+| Day 1 | 80% | 20% |
+| Day 2 | 60% | 40% |
+| Day 3 | 40% | 60% |
+| Day 4 | 20% | 80% |
+| Day 5 | 0% | 100%（展期完成） |
+
+</div>
+
+以 `CLUSDT`（原油）為例，即依循此機制在其指定的標的期貨合約之間過渡（例如由 `WTIK6` 過渡至 `WTIM6`）。
 
 :::info
-此機制將持續優化更新。如需取得最新的展期時程與完整說明，請參閱幫助中心文章：[TradFi 永續合約介紹](https://www.bybit.com/en/help-center/article/Introduction-to-TradFi-Perpetual-Contracts?category=4d5d8649cba144c1a8)。
+如需取得最新的展期時程與完整說明，請參閱幫助中心文章：[TradFi 永續合約介紹](https://www.bybit.com/en/help-center/article/Introduction-to-TradFi-Perpetual-Contracts?category=4d5d8649cba144c1a8)。
 :::
 
 如需查詢指數的當前成分及各成分的權重，可使用 [查詢指數價格成分](/v5/market/index-components) 介面：
 
-```
-GET /v5/market/index-price-components?indexName={symbol}
-```
+<APIEndpoint method="GET" url="/v5/market/index-price-components" />
+
+查詢參數：`indexName={symbol}`
 
 響應包含每個成分的交易所名稱、現貨交易對、等價價格、乘數，以及在指數計算中所占的權重。
 
@@ -109,35 +157,25 @@ GET /v5/market/index-price-components?indexName={symbol}
 
 請使用 [查詢可交易產品的規格信息](/v5/market/instrument) 介面，並搭配 `symbolType` 參數來取得 TradFi 可交易產品的配置規則信息。完整列舉值請參閱 [symbolType 列舉值](/v5/enum#symboltype)。
 
-### xStock 代幣（現貨）
+<APIEndpoint method="GET" url="/v5/market/instruments-info" />
 
-使用 `category=spot` 及 `symbolType=xstocks` 查詢所有 xStock 代幣（如 `TSLAXUSDT`、`AAPLXUSDT`、`NVDAXUSDT`）。
+<div style={{width: 'fit-content'}}>
 
-```
-GET https://api.bybit.com/v5/market/instruments-info?category=spot&symbolType=xstocks&limit=1000
-```
+| 產品類型 | `category` | `symbolType` | 範例 symbol | 特有欄位 |
+|:---|:---|:---|:---|:---|
+| xStock 代幣 | `spot` | `xstocks` | `TSLAXUSDT`、`AAPLXUSDT`、`NVDAXUSDT` | `xstockMultiplier` |
+| 股票永續合約 | `linear` | `stock` | `TSLAUSDT` | — |
+| 大宗商品永續合約 | `linear` | `commodity` | `XAUUSDT`、`XAGUSDT`、`CLUSDT` | — |
 
-響應參數中會包含 xStock 專屬欄位（例如 `xstockMultiplier`）以及 `symbolType: "xstocks"`。
+</div>
 
-### 股票永續合約（Linear）
+股票與大宗商品永續合約皆回傳標準的 linear 合約欄位（槓桿、最小價格變動單位、資金費率間隔等）。
 
-使用 `category=linear` 及 `symbolType=stock` 查詢所有股票永續合約（如 `TSLAUSDT`、`TSMUSDT`、`INTCUSDT`、`HOODUSDT`）。
-
-```
-GET https://api.bybit.com/v5/market/instruments-info?category=linear&symbolType=stock&limit=1000
-```
-
-響應參數中會包含 `symbolType: "stock"`，以及標準的 linear 合約欄位（槓桿、最小價格變動單位、資金費率間隔等）。
-
-### 大宗商品永續合約（Linear）
-
-使用 `category=linear` 及 `symbolType=commodity` 查詢所有大宗商品永續合約（如 `XAUUSDT`、`XAGUSDT`、`CLUSDT`）。
+請求範例：
 
 ```
-GET https://api.bybit.com/v5/market/instruments-info?category=linear&symbolType=commodity&limit=1000
+GET /v5/market/instruments-info?category=linear&symbolType=stock&limit=1000
 ```
-
-響應參數中會包含 `symbolType: "commodity"`，以及標準的 linear 合約欄位（槓桿、最小價格變動單位、資金費率間隔等）。
 
 ## 透過現有 API 交易
 
@@ -156,4 +194,9 @@ GET https://api.bybit.com/v5/market/instruments-info?category=linear&symbolType=
 - [查詢現貨可借額度](/v5/order/spot-borrow-quota)
 - [預檢查訂單](/v5/order/pre-check-order)
 
-僅需在請求中傳入對應的 `symbol`（如 `XAUUSDT`、`XAGUSDT` 用於貴金屬；原油相關 symbol 用於原油合約）與 `category` 即可。
+僅需在請求中傳入對應的 `category` 與 `symbol`：
+
+- **xStock 代幣**：`category=spot`，`symbol` 如 `TSLAXUSDT`、`AAPLXUSDT`
+- **股票永續合約**：`category=linear`，`symbol` 如 `TSLAUSDT`
+- **貴金屬永續合約**：`category=linear`，`symbol` 如 `XAUUSDT`、`XAGUSDT`
+- **原油永續合約**：`category=linear`，`symbol`：`CLUSDT`


### PR DESCRIPTION
- Sign Agreement: align section format with sign-agreement.mdx (APIEndpoint component, Tabs for HTTP/Python, Response Example)
- Index Price Rollover: replace specific dates with generic Day 1-5 weight schedule to mirror Help Center, align front-month / next-month terminology
- Instruments Info: consolidate the three per-symbolType subsections into a single comparison table (category / symbolType / example symbols / notable fields)
- Trade via Existing API: expand "symbol + category" mapping into a per-product bullet list
- Correct xStock spot ticker examples (TSLAX / AAPLX / GOOGLX)
- Remove fabricated stock symbol examples (keep only TSLAUSDT from actual API response)
- Layout: constrain wide tables with width:fit-content